### PR TITLE
use `RecipeHolder` in JEI

### DIFF
--- a/src/main/java/com/tacz/guns/compat/jei/GunModPlugin.java
+++ b/src/main/java/com/tacz/guns/compat/jei/GunModPlugin.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 public class GunModPlugin implements IModPlugin {
     private static final ResourceLocation UID = ResourceLocation.fromNamespaceAndPath(GunMod.MOD_ID, "jei");
 
-    private Map<ResourceLocation, RecipeType<GunSmithTableRecipe>> recipeTypeMap = new HashMap<>();
+    private Map<ResourceLocation, RecipeType<RecipeHolder<GunSmithTableRecipe>>> recipeTypeMap = new HashMap<>();
 
     @Override
     public void registerCategories(IRecipeCategoryRegistration registration) {
@@ -44,7 +44,7 @@ public class GunModPlugin implements IModPlugin {
         for (var entry : map) {
             BlockItem item = entry.getValue().getBlock();
             ItemStack icon = BlockItemBuilder.create(item).setId(entry.getKey()).build();
-            RecipeType<GunSmithTableRecipe> type = RecipeType.create(GunMod.MOD_ID, "gun_smith_table/" + entry.getKey().toString().replace(':', '_'), GunSmithTableRecipe.class);
+            RecipeType<RecipeHolder<GunSmithTableRecipe>> type = RecipeType.createRecipeHolderType(ResourceLocation.fromNamespaceAndPath(GunMod.MOD_ID, "gun_smith_table/" + entry.getKey().toString().replace(':', '_')));
             registration.addRecipeCategories(new GunSmithTableCategory(registration.getJeiHelpers().getGuiHelper(), icon, type, item.getName(icon)));
             recipeTypeMap.put(entry.getKey(), type);
         }
@@ -59,9 +59,9 @@ public class GunModPlugin implements IModPlugin {
 
         for (var entry : recipeTypeMap.entrySet()) {
             TimelessAPI.getCommonBlockIndex(entry.getKey()).ifPresent(blockIndex -> {
-                List<GunSmithTableRecipe> recipeList = blockIndex.getFilter().filter(recipes, RecipeHolder::id).stream().map(RecipeHolder::value).collect(Collectors.toList());
+                List<RecipeHolder<GunSmithTableRecipe>> recipeList = blockIndex.getFilter().filter(recipes, RecipeHolder::id).stream().collect(Collectors.toList());
                 recipeList.removeIf(recipe -> {
-                    return blockIndex.getData().getTabs().stream().noneMatch(tab -> Objects.equals(tab.id(), recipe.getResult().getGroup()));
+                    return blockIndex.getData().getTabs().stream().noneMatch(tab -> Objects.equals(tab.id(), recipe.value().getResult().getGroup()));
                 });
                 registration.addRecipes(entry.getValue(), recipeList);
             });

--- a/src/main/java/com/tacz/guns/compat/jei/category/GunSmithTableCategory.java
+++ b/src/main/java/com/tacz/guns/compat/jei/category/GunSmithTableCategory.java
@@ -13,19 +13,20 @@ import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class GunSmithTableCategory implements IRecipeCategory<GunSmithTableRecipe> {
+public class GunSmithTableCategory implements IRecipeCategory<RecipeHolder<GunSmithTableRecipe>> {
     private final Component title;
     private final IDrawableStatic bgDraw;
     private final IDrawable slotDraw;
     private final IDrawable iconDraw;
-    private final RecipeType<GunSmithTableRecipe> type;
+    private final RecipeType<RecipeHolder<GunSmithTableRecipe>> type;
 
-    public GunSmithTableCategory(IGuiHelper guiHelper, ItemStack icon, RecipeType<GunSmithTableRecipe> type, Component title) {
+    public GunSmithTableCategory(IGuiHelper guiHelper, ItemStack icon, RecipeType<RecipeHolder<GunSmithTableRecipe>> type, Component title) {
         this.bgDraw = guiHelper.createBlankDrawable(160, 40);
         this.slotDraw = guiHelper.getSlotDrawable();
         this.iconDraw = guiHelper.createDrawableIngredient(VanillaTypes.ITEM_STACK, icon);
@@ -34,11 +35,11 @@ public class GunSmithTableCategory implements IRecipeCategory<GunSmithTableRecip
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, GunSmithTableRecipe recipe, IFocusGroup focuses) {
-        ItemStack output = recipe.getOutput();
+    public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<GunSmithTableRecipe> recipe, IFocusGroup focuses) {
+        ItemStack output = recipe.value().getOutput();
         builder.addSlot(RecipeIngredientRole.OUTPUT, 3, 12).addItemStack(output).setBackground(slotDraw, -1, -1);
 
-        List<GunSmithTableIngredient> inputs = recipe.getInputs();
+        List<GunSmithTableIngredient> inputs = recipe.value().getInputs();
         int size = inputs.size();
         // 单行排布
         if (size < 7) {
@@ -89,7 +90,7 @@ public class GunSmithTableCategory implements IRecipeCategory<GunSmithTableRecip
     }
 
     @Override
-    public RecipeType<GunSmithTableRecipe> getRecipeType() {
+    public RecipeType<RecipeHolder<GunSmithTableRecipe>> getRecipeType() {
         return type;
     }
 }


### PR DESCRIPTION
# Summary

In 1.21.1, I know using 'Recipe Holder' is the new standard.
And this can be show the path of the recipe in JEI or EMI, and in other modes using the JEI API.
Please review.

# Reason for request

For get path of the recipe in before, I had to test the item and all recipe's output.
Or create cache like this.
```java
List<RecipeHolder<GunSmithTableRecipe>> recipes = Minecraft.getInstance().level.getRecipeManager().getAllRecipesFor(ModRecipe.GUN_SMITH_TABLE_CRAFTING.get());
Map<GunSmithTableRecipe, ResourceLocation> recipe2IdMap = new HashMap<GunSmithTableRecipe, ResourceLocation>();

for (RecipeHolder<GunSmithTableRecipe> recipe : recipes)
{
	recipe2IdMap.put(recipe.value(), recipe.id());
}
```


# Compare

Before
<img width="491" height="430" alt="image" src="https://github.com/user-attachments/assets/c9db0605-e706-45c4-b9bc-b57d0f3fedc1" />

After
<img width="528" height="430" alt="image" src="https://github.com/user-attachments/assets/fed8527f-1687-46a4-97c4-581e9541a429" />
